### PR TITLE
First add the user then send the message

### DIFF
--- a/XamChat/XamChat/ViewModel/ChatViewModel.cs
+++ b/XamChat/XamChat/ViewModel/ChatViewModel.cs
@@ -54,8 +54,8 @@ namespace XamChat.ViewModel
 
             ChatService.OnReceivedMessage += (sender, args) =>
             {
-                SendLocalMessage(args.Message, args.User);
                 AddRemoveUser(args.User, true);
+                SendLocalMessage(args.Message, args.User);
             };
 
             ChatService.OnEnteredOrExited += (sender, args) =>


### PR DESCRIPTION
This fixes the bug that the first message of the second user is in different color.
Scenario:
1. User 1 joins a room.
2. User 2 joins the room.
3. User 1 can see that the User 2 joined the room, but User 2 doesn't see User 1, until User 1 sends a message. This first message from User 1 is displayed with a random color on the User 2's chat since the User 1 is not yet added to the User 2's list.